### PR TITLE
Improve navigation and settings accessibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,11 +33,11 @@
                 <a href="index.html">ML</a>
             </div>
 
-            <button class="hamburger" aria-label="Toggle menu">
+            <button class="hamburger" aria-label="Toggle menu" aria-expanded="false" aria-controls="primary-navigation">
                 <span></span><span></span><span></span>
             </button>
 
-            <nav>
+            <nav id="primary-navigation" role="navigation" aria-label="Primary navigation">
                 <ul class="nav-list">
                     <li><a href="index.html" data-en="Home" data-no="Hjem">Home</a></li>
                     <li><a href="projects.html" data-en="Projects" data-no="Prosjekter">Projects</a></li>
@@ -50,7 +50,7 @@
 
             <div class="header-actions">
                 <div class="settings-panel">
-                    <button class="settings-toggle" aria-label="Toggle settings">
+                    <button class="settings-toggle" aria-label="Toggle settings" aria-expanded="false" aria-controls="settings-dropdown">
                         <i class="fas fa-cog"></i>
                     </button>
                     <div class="settings-dropdown" id="settings-dropdown">
@@ -58,9 +58,9 @@
                             <div class="settings-item-label">
                                 <i class="fas fa-globe"></i> <span data-en="Language" data-no="Språk">Language</span>
                             </div>
-                            <div class="language-toggle" id="language-toggle">
-                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English">
-                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;">
+                            <div class="language-toggle" id="language-toggle" role="group" aria-label="Language selection">
+                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English" role="button" tabindex="0" aria-pressed="false">
+                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;" role="button" tabindex="0" aria-pressed="true">
                             </div>
                         </div>
                         <div class="settings-item">
@@ -68,7 +68,7 @@
                                 <i class="fas fa-moon"></i> <span id="theme-mode-text" data-en="Dark Mode" data-no="Mørk modus">Dark Mode</span>
                             </div>
                             <label class="theme-toggle">
-                                <input type="checkbox" id="dark-mode-toggle">
+                                <input type="checkbox" id="dark-mode-toggle" aria-labelledby="theme-mode-text">
                                 <span class="theme-slider"></span>
                             </label>
                         </div>

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
                 <a href="index.html">ML</a>
             </div>
 
-            <button class="hamburger" aria-label="Toggle menu">
+            <button class="hamburger" aria-label="Toggle menu" aria-expanded="false" aria-controls="primary-navigation">
                 <span></span><span></span><span></span>
             </button>
 
-            <nav>
+            <nav id="primary-navigation" role="navigation" aria-label="Primary navigation">
                 <ul class="nav-list">
                     <li><a href="index.html" data-en="Home" data-no="Hjem">Home</a></li>
                     <li><a href="projects.html" data-en="Projects" data-no="Prosjekter">Projects</a></li>
@@ -54,7 +54,7 @@
 
             <div class="header-actions">
                 <div class="settings-panel">
-                    <button class="settings-toggle" aria-label="Toggle settings">
+                    <button class="settings-toggle" aria-label="Toggle settings" aria-expanded="false" aria-controls="settings-dropdown">
                         <i class="fas fa-cog"></i>
                     </button>
                     <div class="settings-dropdown" id="settings-dropdown">
@@ -62,9 +62,9 @@
                             <div class="settings-item-label">
                                 <i class="fas fa-globe"></i> <span data-en="Language" data-no="Språk">Language</span>
                             </div>
-                            <div class="language-toggle" id="language-toggle">
-                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English">
-                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;">
+                            <div class="language-toggle" id="language-toggle" role="group" aria-label="Language selection">
+                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English" role="button" tabindex="0" aria-pressed="false">
+                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;" role="button" tabindex="0" aria-pressed="true">
                             </div>
                         </div>
                         <div class="settings-item">
@@ -72,7 +72,7 @@
                                 <i class="fas fa-moon"></i> <span id="theme-mode-text" data-en="Dark Mode" data-no="Mørk modus">Dark Mode</span>
                             </div>
                             <label class="theme-toggle">
-                                <input type="checkbox" id="dark-mode-toggle">
+                                <input type="checkbox" id="dark-mode-toggle" aria-labelledby="theme-mode-text">
                                 <span class="theme-slider"></span>
                             </label>
                         </div>

--- a/js/components/navigation.js
+++ b/js/components/navigation.js
@@ -10,11 +10,21 @@ export function initNavigation() {
 
     if (!hamburger || !nav) return;
 
+    const isDesktopView = window.matchMedia('(min-width: 769px)').matches;
+
+    const setAriaState = isOpen => {
+        hamburger.setAttribute('aria-expanded', String(isOpen));
+        nav.setAttribute('aria-hidden', String(!isOpen));
+    };
+
+    setAriaState(isDesktopView);
+
     const closeMenu = () => {
         nav.classList.remove('open');
         document.body.classList.remove('menu-open');
         hamburger.classList.remove('active');
         document.body.style.overflow = '';
+        setAriaState(false);
     };
 
     const toggleMenu = () => {
@@ -26,6 +36,7 @@ export function initNavigation() {
             document.body.classList.add('menu-open');
             hamburger.classList.add('active');
             document.body.style.overflow = 'hidden';
+            setAriaState(true);
         }
     };
 

--- a/js/components/settings-panel.js
+++ b/js/components/settings-panel.js
@@ -4,8 +4,14 @@ function setActiveFlag(language) {
     const enFlag = select('#en-flag');
     const noFlag = select('#no-flag');
 
-    if (enFlag) enFlag.style.opacity = language === 'en' ? '1' : '0.5';
-    if (noFlag) noFlag.style.opacity = language === 'no' ? '1' : '0.5';
+    if (enFlag) {
+        enFlag.style.opacity = language === 'en' ? '1' : '0.5';
+        enFlag.setAttribute('aria-pressed', language === 'en' ? 'true' : 'false');
+    }
+    if (noFlag) {
+        noFlag.style.opacity = language === 'no' ? '1' : '0.5';
+        noFlag.setAttribute('aria-pressed', language === 'no' ? 'true' : 'false');
+    }
 }
 
 /**
@@ -19,25 +25,48 @@ export function initSettingsPanel({ onLanguageSelect }) {
 
     if (!settingsToggle || !settingsDropdown) return;
 
+    const setDropdownVisibility = isVisible => {
+        settingsDropdown.classList.toggle('visible', isVisible);
+        settingsToggle.setAttribute('aria-expanded', String(isVisible));
+        settingsDropdown.setAttribute('aria-hidden', String(!isVisible));
+    };
+
+    settingsToggle.setAttribute('aria-expanded', 'false');
+    settingsDropdown.setAttribute('aria-hidden', 'true');
+
     settingsToggle.addEventListener('click', event => {
         event.stopPropagation();
-        settingsDropdown.classList.toggle('visible');
+        const willOpen = !settingsDropdown.classList.contains('visible');
+        setDropdownVisibility(willOpen);
     });
 
     document.addEventListener('click', event => {
         if (!settingsDropdown.contains(event.target) && !settingsToggle.contains(event.target)) {
-            settingsDropdown.classList.remove('visible');
+            setDropdownVisibility(false);
         }
     });
 
     if (languageToggle) {
-        languageToggle.addEventListener('click', event => {
-            const target = event.target.closest('.flag-icon');
+        const handleLanguageSelection = target => {
             if (!target) return;
 
             const language = target.dataset.lang || target.id.split('-')[0];
             setActiveFlag(language);
             onLanguageSelect?.(language);
+        };
+
+        languageToggle.addEventListener('click', event => {
+            const target = event.target.closest('.flag-icon');
+            handleLanguageSelection(target);
+        });
+
+        languageToggle.addEventListener('keydown', event => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            const target = event.target.closest('.flag-icon');
+            if (!target) return;
+
+            event.preventDefault();
+            handleLanguageSelection(target);
         });
     }
 

--- a/projects.html
+++ b/projects.html
@@ -33,11 +33,11 @@
                 <a href="index.html">ML</a>
             </div>
 
-            <button class="hamburger" aria-label="Toggle menu">
+            <button class="hamburger" aria-label="Toggle menu" aria-expanded="false" aria-controls="primary-navigation">
                 <span></span><span></span><span></span>
             </button>
 
-            <nav>
+            <nav id="primary-navigation" role="navigation" aria-label="Primary navigation">
                 <ul class="nav-list">
                     <li><a href="index.html" data-en="Home" data-no="Hjem">Home</a></li>
                     <li><a href="projects.html" data-en="Projects" data-no="Prosjekter">Projects</a></li>
@@ -50,7 +50,7 @@
 
             <div class="header-actions">
                 <div class="settings-panel">
-                    <button class="settings-toggle" aria-label="Toggle settings">
+                    <button class="settings-toggle" aria-label="Toggle settings" aria-expanded="false" aria-controls="settings-dropdown">
                         <i class="fas fa-cog"></i>
                     </button>
                     <div class="settings-dropdown" id="settings-dropdown">
@@ -58,9 +58,9 @@
                             <div class="settings-item-label">
                                 <i class="fas fa-globe"></i> <span data-en="Language" data-no="Språk">Language</span>
                             </div>
-                            <div class="language-toggle" id="language-toggle">
-                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English">
-                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;">
+                            <div class="language-toggle" id="language-toggle" role="group" aria-label="Language selection">
+                                <img src="assets/uk-flag.png" class="flag-icon" id="en-flag" data-lang="en" alt="English" role="button" tabindex="0" aria-pressed="false">
+                                <img src="assets/norwegian-flag.png" class="flag-icon" id="no-flag" data-lang="no" alt="Norwegian" style="opacity: 0.5;" role="button" tabindex="0" aria-pressed="true">
                             </div>
                         </div>
                         <div class="settings-item">
@@ -68,7 +68,7 @@
                                 <i class="fas fa-moon"></i> <span id="theme-mode-text" data-en="Dark Mode" data-no="Mørk modus">Dark Mode</span>
                             </div>
                             <label class="theme-toggle">
-                                <input type="checkbox" id="dark-mode-toggle">
+                                <input type="checkbox" id="dark-mode-toggle" aria-labelledby="theme-mode-text">
                                 <span class="theme-slider"></span>
                             </label>
                         </div>

--- a/styles/components/navigation.css
+++ b/styles/components/navigation.css
@@ -23,6 +23,16 @@
     transform: rotate(30deg);
 }
 
+.hamburger:focus-visible,
+.settings-toggle:focus-visible,
+.nav-list a:focus-visible,
+.resume-btn:focus-visible,
+.language-toggle .flag-icon:focus-visible,
+#scroll-top:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 3px;
+}
+
 .settings-dropdown {
     background: rgba(40, 40, 40, 0.95);
     border-radius: 8px;

--- a/styles/features/dark-mode.css
+++ b/styles/features/dark-mode.css
@@ -89,6 +89,9 @@ input:checked + .theme-slider:before {
     background: #3498db;
     box-shadow: 0 0 10px rgba(52, 152, 219, 0.5);
 }
+.theme-toggle input:focus-visible + .theme-slider {
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.35);
+}
 .theme-slider:hover:before {
     box-shadow: 0 0 15px rgba(255, 255, 255, 0.8);
 }


### PR DESCRIPTION
## Summary
- add navigation landmark labelling and aria-expanded controls for the hamburger toggle
- enhance settings dropdown accessibility with keyboard-enabled language selection and pressed states
- provide focus-visible indicators for interactive controls, including the theme toggle slider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab0da174c832b8303f06f9498431e)