### PR TITLE
Add Kildekode and Live demo buttons to project cards and disable card click

### DIFF
--- a/js/features/projects/project-links.js
+++ b/js/features/projects/project-links.js
@@ -30,7 +30,7 @@ export function initProjectLinks() {
       actions.append(
         createActionLink({
           href: github,
-          text: "Kildekode",
+          text: "Source Code",
           variantClass: "project-action-github",
         })
       );
@@ -40,12 +40,17 @@ export function initProjectLinks() {
       actions.append(
         createActionLink({
           href: live,
-          text: "Live demo",
+          text: "Live Demo",
           variantClass: "project-action-live",
         })
       );
     }
 
-    card.append(actions);
+    const description = card.querySelector("p");
+    if (description) {
+      description.insertAdjacentElement("afterend", actions);
+    } else {
+      card.append(actions);
+    }
   });
 }

--- a/js/features/projects/project-links.js
+++ b/js/features/projects/project-links.js
@@ -1,13 +1,45 @@
 import { selectAll } from "../../utils/dom.js";
 
-/**
- * Make project cards clickable while respecting existing anchor semantics.
- */
+function createActionLink({ href, text, variantClass }) {
+  const link = document.createElement("a");
+  link.className = `project-action-btn ${variantClass}`;
+  link.href = href;
+  link.textContent = text;
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  return link;
+}
+
 export function initProjectLinks() {
-  selectAll(".project-link").forEach((card) => {
-    card.addEventListener("click", () => {
-      const url = card.getAttribute("data-url");
-      if (url) window.location.href = url;
-    });
+  selectAll(".project-item").forEach((card) => {
+    const github = card.dataset.github?.trim();
+    const live = card.dataset.live?.trim();
+
+    if (!github && !live) return;
+
+    const actions = document.createElement("div");
+    actions.className = "project-actions";
+
+    if (github) {
+      actions.append(
+        createActionLink({
+          href: github,
+          text: "Kildekode",
+          variantClass: "project-action-github",
+        })
+      );
+    }
+
+    if (live) {
+      actions.append(
+        createActionLink({
+          href: live,
+          text: "Live demo",
+          variantClass: "project-action-live",
+        })
+      );
+    }
+
+    card.append(actions);
   });
 }

--- a/js/features/projects/project-links.js
+++ b/js/features/projects/project-links.js
@@ -2,7 +2,13 @@ import { selectAll } from "../../utils/dom.js";
 
 function createActionLink({ href, text, variantClass }) {
   const link = document.createElement("a");
-  link.className = `project-action-btn ${variantClass}`;
+  link.className = `project-action-btn project-btn ${variantClass}`;
+  if (variantClass === "project-action-live") {
+    link.classList.add("primary");
+  }
+  if (variantClass === "project-action-github") {
+    link.classList.add("secondary");
+  }
   link.href = href;
   link.textContent = text;
   link.target = "_blank";

--- a/projects.html
+++ b/projects.html
@@ -200,6 +200,8 @@
             <div
               class="project-item project-link"
               data-url="https://demo-store-k4g7.onrender.com/"
+              data-github="https://github.com/magnus-lower/demo-store"
+              data-live="https://demo-store-k4g7.onrender.com/"
               data-media-src="assets/ecommerce.png"
               data-media-alt="Preview of the E-Commerce Platform project"
             >
@@ -220,6 +222,8 @@
             <div
               class="project-item project-link"
               data-url="https://weather-dashboard-still-leaf-2476.fly.dev/"
+              data-github="https://github.com/magnus-lower/weather-dashboard"
+              data-live="https://weather-dashboard-still-leaf-2476.fly.dev/"
               data-media-src="assets/weather-dashboard.png"
               data-media-alt="Preview of the Weather Dashboard project"
             >

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -223,7 +223,7 @@ form button:active {
 
 .project-item:hover {
   transform: translateY(-5px);
-  background-color: #e8f4ff;
+  background-color: var(--color-card-surface);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
 }
 
@@ -253,21 +253,25 @@ form button:active {
 .project-actions {
   display: flex;
   justify-content: center;
-  gap: 18px;
-  margin-top: 18px;
+  gap: 22px;
+  margin-top: 28px;
   flex-wrap: wrap;
 }
 
-.project-action-btn {
+.project-action-btn,
+.project-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 20px;
-  border-radius: 999px;
+  padding: 14px 26px;
+  min-width: 180px;
+  max-width: 100%;
+  font-size: 1.05rem;
+  font-weight: 600;
+  border-radius: 9px;
   border: 2px solid transparent;
   background: transparent;
   color: var(--color-primary);
-  font-weight: 600;
   text-decoration: none;
   cursor: pointer;
   transition:
@@ -278,37 +282,44 @@ form button:active {
     box-shadow 0.2s ease;
 }
 
-.project-action-btn:focus-visible {
+.project-action-btn:focus-visible,
+.project-btn:focus-visible {
   outline: 2px solid #1e70bf;
   outline-offset: 2px;
 }
 
-.project-action-live {
+.project-action-live,
+.project-btn.primary {
   background-color: var(--color-primary);
   border-color: var(--color-primary);
-  color: #f8fbff;
-  box-shadow: 0 6px 14px rgba(30, 112, 191, 0.28);
+  color: #ffffff;
+  box-shadow: 0 6px 14px rgba(30, 112, 191, 0.24);
 }
 
-.project-action-live:hover {
+.project-action-live:hover,
+.project-btn.primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(30, 112, 191, 0.34);
-  color: #f8fbff;
+  box-shadow: 0 10px 20px rgba(30, 112, 191, 0.3);
+  color: #ffffff;
   text-decoration: none;
 }
 
-.project-action-github {
+.project-action-github,
+.project-btn.secondary {
   background-color: transparent;
   border-color: var(--color-primary);
   color: var(--color-primary);
   box-shadow: none;
 }
 
-.project-action-github:hover {
+.project-action-github:hover,
+.project-btn.secondary:hover {
+  transform: translateY(-2px);
   background-color: rgba(30, 112, 191, 0.12);
   border-color: var(--color-primary);
   color: var(--color-primary);
   text-decoration: none;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
 }
 
 .project-lang {

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -264,30 +264,51 @@ form button:active {
   justify-content: center;
   padding: 10px 20px;
   border-radius: 999px;
-  border: 2px solid var(--color-primary);
+  border: 2px solid transparent;
   background: transparent;
   color: var(--color-primary);
   font-weight: 600;
   text-decoration: none;
   cursor: pointer;
   transition:
+    transform 0.2s ease,
     background-color 0.2s ease,
     border-color 0.2s ease,
     color 0.2s ease,
     box-shadow 0.2s ease;
 }
 
-.project-action-btn:hover {
-  background-color: rgba(30, 112, 191, 0.12);
-  border-color: #1e70bf;
-  color: #1e70bf;
-  text-decoration: none;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
-}
-
 .project-action-btn:focus-visible {
   outline: 2px solid #1e70bf;
   outline-offset: 2px;
+}
+
+.project-action-live {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #f8fbff;
+  box-shadow: 0 6px 14px rgba(30, 112, 191, 0.28);
+}
+
+.project-action-live:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(30, 112, 191, 0.34);
+  color: #f8fbff;
+  text-decoration: none;
+}
+
+.project-action-github {
+  background-color: transparent;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.project-action-github:hover {
+  background-color: rgba(30, 112, 191, 0.12);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
 }
 
 .project-lang {

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -255,7 +255,7 @@ form button:active {
   justify-content: center;
   gap: 22px;
   margin-top: 28px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .project-action-btn,
@@ -264,7 +264,7 @@ form button:active {
   align-items: center;
   justify-content: center;
   padding: 14px 26px;
-  min-width: 180px;
+  min-width: 160px;
   max-width: 100%;
   font-size: 1.05rem;
   font-weight: 600;
@@ -286,6 +286,17 @@ form button:active {
 .project-btn:focus-visible {
   outline: 2px solid #1e70bf;
   outline-offset: 2px;
+}
+
+@media (max-width: 420px) {
+  .project-actions {
+    flex-wrap: wrap;
+  }
+
+  .project-action-btn,
+  .project-btn {
+    min-width: min(180px, 100%);
+  }
 }
 
 .project-action-live,

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -136,7 +136,7 @@ form button:active {
     transform 0.3s ease-in-out,
     background-color 0.3s ease,
     box-shadow 0.3s ease;
-  cursor: pointer;
+  cursor: default;
 }
 
 .project-media {
@@ -248,6 +248,46 @@ form button:active {
 .project-item a:hover {
   color: #1e70bf;
   text-decoration: underline;
+}
+
+.project-actions {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.project-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 2px solid var(--color-primary);
+  background: transparent;
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.project-action-btn:hover {
+  background-color: rgba(30, 112, 191, 0.12);
+  border-color: #1e70bf;
+  color: #1e70bf;
+  text-decoration: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+}
+
+.project-action-btn:focus-visible {
+  outline: 2px solid #1e70bf;
+  outline-offset: 2px;
 }
 
 .project-lang {


### PR DESCRIPTION
### Motivation
- Provide explicit action buttons for each project card so users can open the GitHub repo or live demo directly instead of navigating by clicking the whole card. 
- Preserve existing media attributes and modal behavior while changing only the card interaction model. 
- Ensure only the action buttons are interactive and the card itself no longer shows a pointer cursor. 
- Fix hover/focus visual behavior for action controls so they remain readable and accessible.

### Description
- Added `data-github` and `data-live` attributes on the project items in `projects.html` to hold action URLs. 
- Reworked `initProjectLinks` in `js/features/projects/project-links.js` to programmatically append a `.project-actions` container with `.project-action-btn.project-action-github` (`Kildekode`) and `.project-action-btn.project-action-live` (`Live demo`) anchors that open in a new tab and include `rel="noopener noreferrer"`, and removed card click navigation. 
- Updated `styles/components/ui-components.css` to set `.project-item` cursor to `default` and add scoped styles for `.project-actions` and `.project-action-btn` including hover and `:focus-visible` rules. 
- Left existing media/image modal logic untouched so image previews and modal behavior continue to work.

### Testing
- Started a local static server with `python -m http.server` and loaded `/projects.html`, which served successfully. 
- Ran an automated Playwright script to open `http://127.0.0.1:8000/projects.html` and capture a screenshot, and the rendered page included the new action buttons (Playwright run succeeded). 
- No additional automated unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ba325744832bb5873c794bea69dc)