### PR TITLE
Add View source / Live demo buttons to project cards and remove full-card navigation

### DIFF
--- a/js/features/projects/project-links.js
+++ b/js/features/projects/project-links.js
@@ -6,32 +6,37 @@ const BUTTON_SELECTORS = {
   demo: ".project-card__btn--demo",
 };
 
-function openUrl(url) {
+function openInNewTab(url) {
   if (!url) return;
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
-/**
- * Attach project card action buttons without making the entire card clickable.
- */
+function openInSameTab(url) {
+  if (!url) return;
+  window.location.href = url;
+}
+
 export function initProjectLinks() {
   selectAll(CARD_SELECTOR).forEach((card) => {
     const githubUrl = card.dataset.githubUrl;
     const demoUrl = card.dataset.demoUrl;
+
     const sourceButton = card.querySelector(BUTTON_SELECTORS.source);
     const demoButton = card.querySelector(BUTTON_SELECTORS.demo);
 
     if (sourceButton) {
       sourceButton.addEventListener("click", (event) => {
+        event.preventDefault();
         event.stopPropagation();
-        openUrl(githubUrl);
+        openInNewTab(githubUrl);
       });
     }
 
     if (demoButton) {
       demoButton.addEventListener("click", (event) => {
+        event.preventDefault();
         event.stopPropagation();
-        openUrl(demoUrl);
+        openInSameTab(demoUrl);
       });
     }
   });

--- a/js/features/projects/project-links.js
+++ b/js/features/projects/project-links.js
@@ -1,13 +1,38 @@
 import { selectAll } from "../../utils/dom.js";
 
+const CARD_SELECTOR = ".project-item";
+const BUTTON_SELECTORS = {
+  source: ".project-card__btn--source",
+  demo: ".project-card__btn--demo",
+};
+
+function openUrl(url) {
+  if (!url) return;
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
 /**
- * Make project cards clickable while respecting existing anchor semantics.
+ * Attach project card action buttons without making the entire card clickable.
  */
 export function initProjectLinks() {
-  selectAll(".project-link").forEach((card) => {
-    card.addEventListener("click", () => {
-      const url = card.getAttribute("data-url");
-      if (url) window.location.href = url;
-    });
+  selectAll(CARD_SELECTOR).forEach((card) => {
+    const githubUrl = card.dataset.githubUrl;
+    const demoUrl = card.dataset.demoUrl;
+    const sourceButton = card.querySelector(BUTTON_SELECTORS.source);
+    const demoButton = card.querySelector(BUTTON_SELECTORS.demo);
+
+    if (sourceButton) {
+      sourceButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        openUrl(githubUrl);
+      });
+    }
+
+    if (demoButton) {
+      demoButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        openUrl(demoUrl);
+      });
+    }
   });
 }

--- a/projects.html
+++ b/projects.html
@@ -198,8 +198,9 @@
           <div class="project-wrapper">
             <h3 class="project-lang"><i class="fab fa-java"></i> Java</h3>
             <div
-              class="project-item project-link"
-              data-url="https://demo-store-k4g7.onrender.com/"
+              class="project-item"
+              data-github-url="https://github.com/magnus-lower/e-commerce-platform"
+              data-demo-url="https://demo-store-k4g7.onrender.com/"
               data-media-src="assets/ecommerce.png"
               data-media-alt="Preview of the E-Commerce Platform project"
             >
@@ -212,14 +213,29 @@
                 data-no="En fullstack e-handelsplattform som bruker Java (Spring Boot), PostgreSQL og Thymeleaf.
                         Inkluderer brukerinnlogging, produktkatalog og handlekurv. Distribuert på Render."
               ></p>
+              <div class="project-card__actions">
+                <button
+                  type="button"
+                  class="btn btn--secondary project-card__btn project-card__btn--source"
+                >
+                  View source
+                </button>
+                <button
+                  type="button"
+                  class="btn btn--primary project-card__btn project-card__btn--demo"
+                >
+                  Live demo
+                </button>
+              </div>
             </div>
           </div>
 
           <div class="project-wrapper">
             <h3 class="project-lang"><i class="fab fa-python"></i> Python</h3>
             <div
-              class="project-item project-link"
-              data-url="https://weather-dashboard-still-leaf-2476.fly.dev/"
+              class="project-item"
+              data-github-url="https://github.com/magnus-lower/weather-dashboard"
+              data-demo-url="https://weather-dashboard-still-leaf-2476.fly.dev/"
               data-media-src="assets/weather-dashboard.png"
               data-media-alt="Preview of the Weather Dashboard project"
             >
@@ -232,6 +248,20 @@
                 data-no="Et værdashbord som er bygget med Python (Flask), OpenWeather API og Bootstrap.
                         Viser live data, og stedsbasert værdata. Distribuert på Fly.io."
               ></p>
+              <div class="project-card__actions">
+                <button
+                  type="button"
+                  class="btn btn--secondary project-card__btn project-card__btn--source"
+                >
+                  View source
+                </button>
+                <button
+                  type="button"
+                  class="btn btn--primary project-card__btn project-card__btn--demo"
+                >
+                  Live demo
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -218,19 +218,13 @@
                   type="button"
                   class="btn btn--secondary project-card__btn project-card__btn--source"
                 >
-                <span
-                  data-en="View source"
-                  data-no="Se kildekode"
-                >
+                  <span data-en="View source" data-no="Se kildekode"></span>
                 </button>
                 <button
                   type="button"
                   class="btn btn--primary project-card__btn project-card__btn--demo"
                 >
-                <span
-                  data-en="Live demo"
-                  data-no="Live demo"
-                >
+                  <span data-en="Live demo" data-no="Live demo"></span>
                 </button>
               </div>
             </div>
@@ -259,19 +253,13 @@
                   type="button"
                   class="btn btn--secondary project-card__btn project-card__btn--source"
                 >
-                <span
-                  data-en="View source"
-                  data-no="Se kildekode"
-                  >
+                  <span data-en="View source" data-no="Se kildekode"></span>
                 </button>
                 <button
                   type="button"
                   class="btn btn--primary project-card__btn project-card__btn--demo"
                 >
-                <span
-                  data-en="Live demo"
-                  data-no="Live demo"
-                  >
+                  <span data-en="Live demo" data-no="Live demo"></span>
                 </button>
               </div>
             </div>

--- a/projects.html
+++ b/projects.html
@@ -199,7 +199,7 @@
             <h3 class="project-lang"><i class="fab fa-java"></i> Java</h3>
             <div
               class="project-item"
-              data-github-url="https://github.com/magnus-lower/e-commerce-platform"
+              data-github-url="https://github.com/magnus-lower/demo-store"
               data-demo-url="https://demo-store-k4g7.onrender.com/"
               data-media-src="assets/ecommerce.png"
               data-media-alt="Preview of the E-Commerce Platform project"
@@ -218,13 +218,19 @@
                   type="button"
                   class="btn btn--secondary project-card__btn project-card__btn--source"
                 >
-                  View source
+                <span
+                  data-en="View source"
+                  data-no="Se kildekode"
+                >
                 </button>
                 <button
                   type="button"
                   class="btn btn--primary project-card__btn project-card__btn--demo"
                 >
-                  Live demo
+                <span
+                  data-en="Live demo"
+                  data-no="Live demo"
+                >
                 </button>
               </div>
             </div>
@@ -253,13 +259,19 @@
                   type="button"
                   class="btn btn--secondary project-card__btn project-card__btn--source"
                 >
-                  View source
+                <span
+                  data-en="View source"
+                  data-no="Se kildekode"
+                  >
                 </button>
                 <button
                   type="button"
                   class="btn btn--primary project-card__btn project-card__btn--demo"
                 >
-                  Live demo
+                <span
+                  data-en="Live demo"
+                  data-no="Live demo"
+                  >
                 </button>
               </div>
             </div>

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -36,8 +36,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 18px;
-  border-radius: 6px;
+  padding: 1px 18px;
+  border-radius: 9px;
   font-size: 1em;
   font-weight: 600;
   border: 2px solid transparent;

--- a/styles/components/ui-components.css
+++ b/styles/components/ui-components.css
@@ -32,6 +32,54 @@
   color: white;
 }
 
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 6px;
+  font-size: 1em;
+  font-weight: 600;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.btn--primary {
+  background-color: var(--color-primary);
+  color: #ffffff;
+  box-shadow: 0 4px 10px rgba(52, 152, 219, 0.2);
+}
+
+.btn--primary:hover {
+  background-color: #1e70bf;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(52, 152, 219, 0.3);
+}
+
+.btn--secondary {
+  background-color: transparent;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn--secondary:hover {
+  background-color: var(--color-primary);
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(52, 152, 219, 0.2);
+}
+
 form {
   background: var(--color-card-surface);
   border-radius: 10px;
@@ -136,7 +184,9 @@ form button:active {
     transform 0.3s ease-in-out,
     background-color 0.3s ease,
     box-shadow 0.3s ease;
-  cursor: pointer;
+  cursor: default;
+  display: flex;
+  flex-direction: column;
 }
 
 .project-media {
@@ -236,6 +286,17 @@ form button:active {
   font-size: 1.1em;
   margin-bottom: 15px;
   flex-grow: 1;
+}
+
+.project-card__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
+
+.project-card__btn {
+  flex: 1 1 140px;
 }
 
 .project-item a {


### PR DESCRIPTION
### Motivation
- Replace the existing behavior where clicking anywhere on a project card navigates to the demo with explicit action buttons for source and demo links.
- Ensure visible button labels are present in HTML while keeping navigation logic in JavaScript.
- Preserve the card visual design and improve accessibility by keeping buttons keyboard-reachable and removing the card pointer cursor.

### Description
- Updated `projects.html` to remove the `project-link` full-card click behavior, add `data-github-url` and `data-demo-url` attributes, and insert a `.project-card__actions` row with hardcoded `View source` and `Live demo` buttons inside each `.project-item`.
- Replaced the previous click-on-card logic with `js/features/projects/project-links.js` that now attaches `click` handlers only to the `.project-card__btn--source` and `.project-card__btn--demo` buttons and opens links with `window.open(..., "_blank", "noopener,noreferrer")`, while calling `event.stopPropagation()` to prevent bubbling.
- Added button and layout styles to `styles/components/ui-components.css` (new `.btn`, `.btn--primary`, `.btn--secondary`, `.project-card__actions`, `.project-card__btn`) and removed the pointer cursor from `.project-item` while making it a column flex container so actions sit at the bottom.
- Kept media modal behavior intact and ensured project media button clicks still call `stopPropagation()` so media opens without card navigation interference.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the site and the command succeeded.
- Captured a full-page screenshot of `http://127.0.0.1:8000/projects.html` using Playwright which succeeded and produced `artifacts/projects-buttons.png` showing the new buttons visible on the project cards.
- No unit tests were present for this UI change, and no automated test failures occurred during the above checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957de898118832baaaeacb0bac5ab72)