### PR TITLE
Ensure Settings panel stays fully visible (fixed positioning + viewport clamping)

### DIFF
--- a/js/components/settings-panel.js
+++ b/js/components/settings-panel.js
@@ -28,10 +28,41 @@ export function initSettingsPanel({ onLanguageSelect }) {
 
   if (!settingsToggle || !settingsDropdown) return;
 
+  const updateDropdownPosition = () => {
+    const toggleRect = settingsToggle.getBoundingClientRect();
+    const dropdownRect = settingsDropdown.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const horizontalPadding = 12;
+    const verticalPadding = 12;
+    const verticalOffset = window.matchMedia("(max-width: 768px)").matches
+      ? 19
+      : 0;
+
+    let left = toggleRect.right - dropdownRect.width;
+    let top = toggleRect.bottom + verticalOffset;
+
+    if (left < horizontalPadding) {
+      left = horizontalPadding;
+    } else if (left + dropdownRect.width > viewportWidth - horizontalPadding) {
+      left = Math.max(horizontalPadding, viewportWidth - dropdownRect.width - horizontalPadding);
+    }
+
+    if (top + dropdownRect.height > viewportHeight - verticalPadding) {
+      top = Math.max(verticalPadding, viewportHeight - dropdownRect.height - verticalPadding);
+    }
+
+    settingsDropdown.style.setProperty("--settings-dropdown-left", `${Math.round(left)}px`);
+    settingsDropdown.style.setProperty("--settings-dropdown-top", `${Math.round(top)}px`);
+  };
+
   const setDropdownVisibility = (isVisible) => {
     settingsDropdown.classList.toggle("visible", isVisible);
     settingsToggle.setAttribute("aria-expanded", String(isVisible));
     settingsDropdown.setAttribute("aria-hidden", String(!isVisible));
+    if (isVisible) {
+      requestAnimationFrame(updateDropdownPosition);
+    }
   };
 
   settingsToggle.setAttribute("aria-expanded", "false");
@@ -60,6 +91,12 @@ export function initSettingsPanel({ onLanguageSelect }) {
       !settingsToggle.contains(event.target)
     ) {
       setDropdownVisibility(false);
+    }
+  });
+
+  window.addEventListener("resize", () => {
+    if (settingsDropdown.classList.contains("visible")) {
+      updateDropdownPosition();
     }
   });
 

--- a/js/components/settings-panel.js
+++ b/js/components/settings-panel.js
@@ -31,6 +31,10 @@ export function initSettingsPanel({ onLanguageSelect }) {
   const updateDropdownPosition = () => {
     const toggleRect = settingsToggle.getBoundingClientRect();
     const dropdownRect = settingsDropdown.getBoundingClientRect();
+    if (!dropdownRect.width || !dropdownRect.height) {
+      requestAnimationFrame(updateDropdownPosition);
+      return;
+    }
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const horizontalPadding = 12;
@@ -61,7 +65,7 @@ export function initSettingsPanel({ onLanguageSelect }) {
     settingsToggle.setAttribute("aria-expanded", String(isVisible));
     settingsDropdown.setAttribute("aria-hidden", String(!isVisible));
     if (isVisible) {
-      requestAnimationFrame(updateDropdownPosition);
+      requestAnimationFrame(() => requestAnimationFrame(updateDropdownPosition));
     }
   };
 

--- a/styles/features/responsive.css
+++ b/styles/features/responsive.css
@@ -31,8 +31,6 @@
     max-width: 100%;
   }
   .settings-dropdown {
-    right: -10px;
-    top: calc(100% + 19px);
     width: min(260px, 92vw);
     min-width: 220px;
   }

--- a/styles/layout/header-layout.css
+++ b/styles/layout/header-layout.css
@@ -33,9 +33,9 @@
 }
 
 .settings-dropdown {
-  position: absolute;
-  right: 0;
-  top: 100%;
+  position: fixed;
+  left: var(--settings-dropdown-left, 0);
+  top: var(--settings-dropdown-top, 0);
   width: min(280px, 92vw);
   min-width: 240px;
   padding: 15px;


### PR DESCRIPTION
### Motivation
- The Settings dropdown was absolutely positioned inside the header which could be clipped by the header's positioning/stacking and by mobile nav behavior, causing the panel to appear partially off-screen.  
- The goal is to ensure the panel is always fully visible and interactive across common viewport sizes without changing visuals or behavior.  

### Description
- Change `.settings-dropdown` from `position: absolute` to `position: fixed` and drive its coordinates with CSS variables `--settings-dropdown-left` and `--settings-dropdown-top`.  
- Remove the previous right/top offset in the mobile responsive rules so the fixed coordinates control placement consistently.  
- Add `updateDropdownPosition()` in `initSettingsPanel` to compute viewport-aware left/top using the toggle and dropdown bounding boxes and clamp the panel inside the viewport, and apply these values when opening and on `resize`.  
- Keep existing open/close logic, ARIA attributes, and appearance/animations unchanged, only adjusting placement to avoid clipping.  

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the site which started successfully.  
- Attempted an automated Playwright script that navigates to `/index.html`, clicks the gear icon and captures a screenshot, but the Playwright run timed out (failed) during execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7ba3f13c832b9f7936618dcac662)