### PR TITLE
Tweak vertical spacing above primary CTAs in Hero and About sections

### DIFF
--- a/styles/components/hero.css
+++ b/styles/components/hero.css
@@ -10,7 +10,7 @@
 
 .hero-content p {
   font-size: 1.2em;
-  margin-bottom: 20px;
+  margin-bottom: 28px;
 }
 
 .contact-links a {

--- a/styles/layout/section-layout.css
+++ b/styles/layout/section-layout.css
@@ -46,7 +46,7 @@
 .about-preview > p,
 .projects > p {
   max-width: 60ch;
-  margin: 0 auto 20px;
+  margin: 0 auto 26px;
   padding-inline: 16px;
 }
 


### PR DESCRIPTION
### Motivation

- Improve vertical rhythm and hierarchy by increasing the space above primary call-to-action buttons in the hero and about-preview sections. 
- Make a minimal, surgical change that only affects vertical spacing above these CTAs while preserving all functionality, sizes, colors, and interactions. 

### Description

- Increased the bottom margin of the hero paragraph by changing `margin-bottom` in `styles/components/hero.css` for `.hero-content p` from `20px` to `28px` to add breathing room above the hero CTA. 
- Increased the bottom margin of the about-preview paragraph by changing `margin` in `styles/layout/section-layout.css` for `.about-preview > p` (and `.projects > p`) from `0 auto 20px` to `0 auto 26px` to add a small gap above the secondary CTA. 
- Changes are minimal and scoped to the existing selectors to avoid affecting other elements or responsive behavior. 

### Testing

- Launched a local dev server with `python -m http.server 8000` and the server started successfully. 
- Captured a full-page screenshot of `index.html` using Playwright to verify the spacing visually and the run completed successfully. 
- No runtime functionality or automated test suites were modified, and the visual spacing adjustments are limited to the two CSS rules above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcf336b88832ba51d62ca18a9171b)